### PR TITLE
Replace logrus by log/slog

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -11,7 +11,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Get version number
         id: version
         run: echo "version=$(echo ${{ github.ref_name }} | cut -c2- -)" >> $GITHUB_OUTPUT

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,9 +17,9 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - name: Checkout
-          uses: actions/checkout@v6
+          uses: actions/checkout@v7
         - name: Setup Go
-          uses: actions/setup-go@v6
+          uses: actions/setup-go@v7
           with:
             go-version-file: go.mod
         - name: Test

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,6 +9,6 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
-    - uses: actions/setup-python@v6
+    - uses: actions/checkout@v7
+    - uses: actions/setup-python@v7
     - uses: pre-commit/action@v3.0.1

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,5 @@
 module github.com/nextmn/json-api
 
-go 1.25.5
+go 1.26.6
 
-require (
-	github.com/gofrs/uuid/v5 v5.4.0
-	github.com/sirupsen/logrus v1.9.4
-)
-
-require golang.org/x/sys v0.13.0 // indirect
+require github.com/gofrs/uuid/v5 v5.5.1

--- a/go.sum
+++ b/go.sum
@@ -1,14 +1,2 @@
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/gofrs/uuid/v5 v5.4.0 h1:EfbpCTjqMuGyq5ZJwxqzn3Cbr2d0rUZU7v5ycAk/e/0=
-github.com/gofrs/uuid/v5 v5.4.0/go.mod h1:CDOjlDMVAtN56jqyRUZh58JT31Tiw7/oQyEXZV+9bD8=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
-github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
-github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
-github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
-github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
-golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
-gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+github.com/gofrs/uuid/v5 v5.5.1 h1:z1Ce19/JwNidXpy3tOQc3241lnJLKdKyq/xlNvlD4Ng=
+github.com/gofrs/uuid/v5 v5.5.1/go.mod h1:bbAA98EoIlxyRHIVg6ektCSsZ5n8mSbwgEhvhMYlZgg=

--- a/healthcheck/healthcheck.go
+++ b/healthcheck/healthcheck.go
@@ -9,11 +9,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"time"
-
-	"github.com/sirupsen/logrus"
 )
 
 // Healthcheck allows to check status of the node
@@ -42,7 +41,7 @@ func (h *Healthcheck) Run(ctx context.Context) error {
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, h.url, nil)
 	if err != nil {
-		logrus.WithError(err).Error("Error while creating http get request")
+		slog.ErrorContext(ctx, "Error while creating http get request", "error", err)
 		return err
 	}
 	req.Header.Add("User-Agent", h.userAgent)
@@ -50,23 +49,35 @@ func (h *Healthcheck) Run(ctx context.Context) error {
 	req.Header.Set("Accept-Charset", "utf-8")
 	resp, err := client.Do(req)
 	if err != nil {
-		logrus.WithFields(logrus.Fields{"remote-server": h.url}).WithError(err).Info("No http response")
+		slog.InfoContext(ctx, "No HTTP response",
+			"error", err,
+			"remote-server", h.url,
+		)
 		return err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
-		logrus.WithFields(logrus.Fields{"remote-server": h.url}).WithError(err).Info("Http response is not 200 OK")
+		slog.InfoContext(ctx, "HTTP response is not 200 OK",
+			"error", err,
+			"remote-server", h.url,
+		)
 		return err
 	}
 	decoder := json.NewDecoder(resp.Body)
 	var status Status
 	if err := decoder.Decode(&status); err != nil {
-		logrus.WithFields(logrus.Fields{"remote-server": h.url}).WithError(err).Info("Could not decode json response")
+		slog.InfoContext(ctx, "Could not decode JSON response",
+			"error", err,
+			"remote-server", h.url,
+		)
 		return err
 	}
 	if !status.Ready {
 		err := fmt.Errorf("server is not ready")
-		logrus.WithFields(logrus.Fields{"remote-server": h.url}).WithError(err).Info("Server is not ready")
+		slog.InfoContext(ctx, "Server is not ready",
+			"error", err,
+			"remote-server", h.url,
+		)
 		return err
 	}
 	return nil


### PR DESCRIPTION
Because a logrus hook is available, so applications can choose to not use it.